### PR TITLE
Python3 dynamic CSV file encodings

### DIFF
--- a/ScribusGenerator.py
+++ b/ScribusGenerator.py
@@ -126,11 +126,10 @@ class GeneratorControl:
 
     def getToVariable(self):
         return self.__toVariable
-        
+
     def getCloseDialogVariable(self):
         return self.__closeDialogVariable
-   
-        
+
 
     def allValuesSet(self):
         # Simple check whether input fields are NOT EMPTY.
@@ -354,7 +353,7 @@ class GeneratorDialog:
         outputFormatListBox = OptionMenu(outputFrame, self.__ctrl.getSelectedOutputFormat(), *self.__ctrl.getOutputFormatList(),
                                          command=lambda v=self.__ctrl.getSelectedOutputFormat(): self.updateState(v))
         outputFormatListBox.grid(column=5, row=1, padx=5, pady=5, sticky='w')
-        
+
         mergeOutputLabel = Label(
             outputFrame, text='Merge in Single File:', width=17, anchor='w')
         mergeOutputLabel.grid(column=0,  columnspan=2, row=2, padx=5, pady=5, sticky='w')
@@ -371,7 +370,6 @@ class GeneratorDialog:
         self.keepGeneratedScribusFilesCheckbox.grid(
             column=5, row=2, padx=5, pady=5, sticky='w')
 
-        
         # Misc Settings
         saveLabel = Label(miscFrame, text='Save Settings:',
                           width=12, anchor='w')
@@ -387,7 +385,6 @@ class GeneratorDialog:
             miscFrame, variable=self.__ctrl.getCloseDialogVariable())
         closeCheckbox.grid(column=5, row=1, padx=5, pady=5, sticky='e')
 
-        
         # Bottom Buttons
         generateButton = Button(
             buttonFrame, text='✔\nGenerate', width=10, command=self.__ctrl.buttonOkHandler)

--- a/ScribusGenerator.py
+++ b/ScribusGenerator.py
@@ -46,6 +46,8 @@ class GeneratorControl:
         self.__scribusSourceFileEntryVariable = StringVar()
         self.__dataSeparatorEntryVariable = StringVar()
         self.__dataSeparatorEntryVariable.set(CONST.CSV_SEP)
+        self.__dataEncodingEntryVariable = StringVar()
+        self.__dataEncodingEntryVariable.set(CONST.CSV_ENCODING)
         self.__outputDirectoryEntryVariable = StringVar()
         self.__outputFileNameEntryVariable = StringVar()
         # SLA & PDF are valid output format
@@ -89,6 +91,9 @@ class GeneratorControl:
 
     def getDataSeparatorEntryVariable(self):
         return self.__dataSeparatorEntryVariable
+
+    def getDataEncodingEntryVariable(self):
+        return self.__dataEncodingEntryVariable
 
     def getOutputDirectoryEntryVariable(self):
         return self.__outputDirectoryEntryVariable
@@ -134,6 +139,7 @@ class GeneratorControl:
         if((self.__scribusSourceFileEntryVariable.get() != CONST.EMPTY) and
             (self.__dataSourceFileEntryVariable.get() != CONST.EMPTY) and
             (self.__outputDirectoryEntryVariable.get() != CONST.EMPTY) and
+            (len(self.__dataEncodingEntryVariable.get()) >= 4 ) and
                 (len(self.__dataSeparatorEntryVariable.get()) == 1)):
             result = 1
         return result
@@ -148,6 +154,7 @@ class GeneratorControl:
             outputFormat=self.__selectedOutputFormat.get(),
             keepGeneratedScribusFiles=self.__keepGeneratedScribusFilesCheckboxVariable.get(),
             csvSeparator=self.__dataSeparatorEntryVariable.get(),
+            csvEncoding=self.__dataEncodingEntryVariable.get(),
             singleOutput=self.__mergeOutputCheckboxVariable.get(),
             firstRow=self.__fromVariable.get(),
             lastRow=self.__toVariable.get(),
@@ -206,6 +213,7 @@ class GeneratorControl:
             self.__dataSourceFileEntryVariable.set(
                 dataObject.getDataSourceFile())
             self.__dataSeparatorEntryVariable.set(dataObject.getCsvSeparator())
+            self.__dataEncodingEntryVariable.set(dataObject.getCsvEncoding())
             self.__outputDirectoryEntryVariable.set(
                 dataObject.getOutputDirectory())
             self.__outputFileNameEntryVariable.set(
@@ -299,6 +307,13 @@ class GeneratorDialog:
         dataSeparatorEntry = Entry(
             inputFrame, width=3, textvariable=self.__ctrl.getDataSeparatorEntryVariable())
         dataSeparatorEntry.grid(column=1, row=2, padx=5, pady=5, sticky='w')
+
+        dataEncodingLabel = Label(
+            inputFrame, text='Data Encoding:', width=15, anchor='w')
+        dataEncodingLabel.grid(column=0, row=3, padx=5, pady=5, sticky='w')
+        dataEncodingEntry = Entry(
+            inputFrame, width=15, textvariable=self.__ctrl.getDataEncodingEntryVariable())
+        dataEncodingEntry.grid(column=1, row=3, padx=5, pady=5, sticky='w')
 
         fromLabel = Label(
             inputFrame, text='(opt.) use partial data, only from:', anchor='e')

--- a/ScribusGeneratorBackend.py
+++ b/ScribusGeneratorBackend.py
@@ -48,6 +48,7 @@ class CONST:
     SEP_EXT = os.extsep
     # CSV entry separator, comma by default; tab: " " is also common if using Excel.
     CSV_SEP = ","
+    CSV_ENCODING = 'utf-8'
     # indent the generated SLA code for more readability, aka "XML pretty print". set to 0 to (slighlty) speed up the generation.
     INDENT_SLA = 1
     CONTRIB_TEXT = "\npowered by ScribusGenerator - https://github.com/berteh/ScribusGenerator/"
@@ -460,7 +461,7 @@ class ScribusGenerator:
 
     def readFileContent(self, src):
         # Returns the list of lines (as strings) of the text-file
-        tmp = open(src, 'r', encoding='utf-8')
+        tmp = open(src, 'r', encoding=self.__dataObject.getCsvEncoding())
         result = tmp.readlines()
         tmp.close()
         return result
@@ -558,7 +559,7 @@ class ScribusGenerator:
         # Read CSV file and return array or dict [(var1,value1), (var2,value2),..]
         
         result = []        
-        with open(csvfile, newline='', encoding='utf-8') as csvf:
+        with open(csvfile, newline='', encoding=self.__dataObject.getCsvEncoding()) as csvf:
             reader = csv.DictReader(csvf, delimiter=self.__dataObject.getCsvSeparator(), skipinitialspace=True, doublequote=True)
             for row in reader:
                 if(len(row) > 0): # strip empty lines in source CSV
@@ -597,6 +598,7 @@ class GeneratorDataObject:
                  outputFormat=CONST.EMPTY,
                  keepGeneratedScribusFiles=CONST.FALSE,
                  csvSeparator=CONST.CSV_SEP,
+                 csvEncoding=CONST.CSV_ENCODING,
                  singleOutput=CONST.FALSE,
                  firstRow=CONST.EMPTY,
                  lastRow=CONST.EMPTY,
@@ -609,6 +611,7 @@ class GeneratorDataObject:
         self.__outputFormat = outputFormat
         self.__keepGeneratedScribusFiles = keepGeneratedScribusFiles
         self.__csvSeparator = csvSeparator
+        self.__csvEncoding = csvEncoding
         self.__singleOutput = singleOutput
         self.__firstRow = firstRow
         self.__lastRow = lastRow
@@ -637,6 +640,9 @@ class GeneratorDataObject:
     def getCsvSeparator(self):
         return self.__csvSeparator
 
+    def getCsvEncoding(self):
+        return self.__csvEncoding
+
     def getSingleOutput(self):
         return self.__singleOutput
 
@@ -651,7 +657,7 @@ class GeneratorDataObject:
 
     def getCloseDialog(self):
         return self.__closeDialog
-        
+
 
     # Set
     def setScribusSourceFile(self, fileName):
@@ -674,6 +680,9 @@ class GeneratorDataObject:
 
     def setCsvSeparator(self, value):
         self.__csvSeparator = value
+
+    def setCsvEncoding(self, value):
+        self.__csvEncoding = value
 
     def setSingleOutput(self, value):
         self.__singleOutput = value
@@ -701,6 +710,7 @@ class GeneratorDataObject:
             'outformat': self.__outputFormat,
             'keepsla': self.__keepGeneratedScribusFiles,
             'separator': self.__csvSeparator,
+            'csvencoding': self.__csvEncoding,
             'single': self.__singleOutput,
             'from': self.__firstRow,
             'to': self.__lastRow,
@@ -722,6 +732,7 @@ class GeneratorDataObject:
         self.__keepGeneratedScribusFiles = j['keepsla']
         # str()to prevent TypeError: : "delimiter" must be string, not unicode, in csv.reader() call
         self.__csvSeparator = str(j['separator'])
+        self.__csvEncoding = str(j['csvencoding'])
         self.__singleOutput = j["single"]
         self.__firstRow = j["from"]
         self.__lastRow = j["to"]

--- a/ScribusGeneratorBackend.py
+++ b/ScribusGeneratorBackend.py
@@ -171,12 +171,12 @@ class ScribusGenerator:
         recordsInDocument = 1 + rootStr.count(CONST.NEXT_RECORD)
         logging.info("source document consumes %s data record(s) from %s." %
                      (recordsInDocument, dataC))
-        
+
         #global vars
         dataBuffer = []
         pagescount = pageheight = vgap = groupscount = objscount = 0
         version = ''
-        
+
         for row in csvData:
             if(index == 0):  # get vars names from first Header-Row of the CSV-File
                 varNamesForFileName = list(row.keys())
@@ -187,7 +187,7 @@ class ScribusGenerator:
             # now handle row as data entry
             # accumulate row in buffer
             dataBuffer.append(row.values())
-            
+
             # buffered data for all document records OR reached last data record
             if ((index+1) % recordsInDocument == 0) or index == dataC:
                 logging.debug("subsitute")
@@ -253,8 +253,7 @@ class ScribusGenerator:
                 self.deleteFile(scribusOutputFilePath)
 
         return 1
- 
- 
+
     def exportPDF(self, scribusFilePath, pdfFilePath):
         import scribus
 
@@ -336,16 +335,16 @@ class ScribusGenerator:
         shifted = []
         voffset = (float(pageheight)+float(vgap)) * \
             (index // recordsInDocument)
-        #logging.debug("shifting to voffset %s " % (voffset)) 
+        #logging.debug("shifting to voffset %s " % (voffset))
         for page in docElt.findall('PAGE'):
             page.set('PAGEYPOS', str(float(page.get('PAGEYPOS')) + voffset))
             page.set('NUM', str(int(page.get('NUM')) + pagescount))
             shifted.append(page)
         for obj in docElt.findall('PAGEOBJECT'):
             ypos = obj.get('YPOS')
-            if (ypos == "" ): 
+            if (ypos == "" ):
                 ypos = 0
-            #logging.debug("original YPOS is %s " % (ypos)) 
+            #logging.debug("original YPOS is %s " % (ypos))
             obj.set('YPOS', str(float(ypos) + voffset))
             obj.set('OwnPage', str(int(obj.get('OwnPage')) + pagescount))
             # update ID and links
@@ -557,8 +556,8 @@ class ScribusGenerator:
 
     def getCsvData(self, csvfile):
         # Read CSV file and return array or dict [(var1,value1), (var2,value2),..]
-        
-        result = []        
+
+        result = []
         with open(csvfile, newline='', encoding=self.__dataObject.getCsvEncoding()) as csvf:
             reader = csv.DictReader(csvf, delimiter=self.__dataObject.getCsvSeparator(), skipinitialspace=True, doublequote=True)
             for row in reader:

--- a/ScribusGeneratorBackend.py
+++ b/ScribusGeneratorBackend.py
@@ -289,10 +289,10 @@ class ScribusGenerator:
         if (indentSLA):
             from xml.dom import minidom
             xmlstr = minidom.parseString(ET.tostring(outTree.getroot())).toprettyxml(indent="   ")
-            with open(scribusOutputFilePath, "w") as f:
+            with open(scribusOutputFilePath, "w", encoding='utf-8') as f:
                 f.write(xmlstr)
         else:
-            outTree.write(scribusOutputFilePath, encoding="UTF-8")
+            outTree.write(scribusOutputFilePath, encoding='utf-8')
         logging.info("scribus file created: %s" % (scribusOutputFilePath))
         return scribusOutputFilePath
 
@@ -460,7 +460,7 @@ class ScribusGenerator:
 
     def readFileContent(self, src):
         # Returns the list of lines (as strings) of the text-file
-        tmp = open(src, 'r')
+        tmp = open(src, 'r', encoding='utf-8')
         result = tmp.readlines()
         tmp.close()
         return result
@@ -558,7 +558,7 @@ class ScribusGenerator:
         # Read CSV file and return array or dict [(var1,value1), (var2,value2),..]
         
         result = []        
-        with open(csvfile, newline='') as csvf:
+        with open(csvfile, newline='', encoding='utf-8') as csvf:
             reader = csv.DictReader(csvf, delimiter=self.__dataObject.getCsvSeparator(), skipinitialspace=True, doublequote=True)
             for row in reader:
                 if(len(row) > 0): # strip empty lines in source CSV

--- a/ScribusGeneratorCLI.py
+++ b/ScribusGeneratorCLI.py
@@ -74,6 +74,8 @@ parser.add_argument('-c', '--csvFile', default=None,
                     help='CSV file containing the data to substitute in each template during generation. Default is scribus source file(s) name with "csv" extension instead of "sla". If csv file is not found, generation from this particular template is skipped.')
 parser.add_argument('-d', '--csvDelimiter', default=CONST.CSV_SEP,
                     help='CSV field delimiter character. Default is comma: ","')
+parser.add_argument('-e', '--csvEncoding', default=CONST.CSV_ENCODING,
+                    help='Encoding of the CSV file (default: utf-8)')
 # parser.add_argument('-f', '--fast', '--noPdf', action='store_true', default=False, # commented utile Scribus allows pdf generation from command line
 #    help='no PDF generation, scribus SLA only (much faster)')
 parser.add_argument('-n', '--outName', default=CONST.EMPTY,
@@ -125,6 +127,7 @@ dataObject = GeneratorDataObject(
     # ife(args.pdfOnly, CONST.FALSE, CONST.TRUE), # not used if outputFormat is sla.
     keepGeneratedScribusFiles=CONST.TRUE,
     csvSeparator=args.csvDelimiter,  # is CONST.CSV_SEP by default
+    csvEncoding=args.csvEncoding, # is CONST.CSV_ENCODING by default
     singleOutput=args.merge,
     firstRow=args.firstRow,
     lastRow=args.lastRow,

--- a/ScribusGeneratorCLI.py
+++ b/ScribusGeneratorCLI.py
@@ -43,23 +43,23 @@ parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpForm
     This program requires Python 2.7+
 
 examples:
-    
+
   %(prog)s my-template.sla
     generates Scribus (SLA) files for each line of 'my-template.csv'
-    by subsituting the provides values into 'my-template.sla' to the 
+    by subsituting the provides values into 'my-template.sla' to the
     current directory.
 
-  %(prog)s --outDir "/home/user/tmp" example/Business_Card.sla 
+  %(prog)s --outDir "/home/user/tmp" example/Business_Card.sla
     generates Scribus files for each line of example/Business_Card.csv
     in the "/home/user/tmp" subdirectory.
 
-  %(prog)s --outName "card_%%VAR_email%%"  */*.sla 
+  %(prog)s --outName "card_%%VAR_email%%"  */*.sla
     generates Scribus files for each sla file in any subdirectory
     that has a csv file with a similar name in the same directory.
     Generated files will have a name constructed from the "email" field
     data, and are stored in their respective sla file directory.
 
-  %(prog)s --single -c translations.csv -n doc_  lang/*.sla 
+  %(prog)s --single -c translations.csv -n doc_  lang/*.sla
     generates a single Scribus file for each sla file in the lang/ subdirectory
     using all rows of the translations.csv data file.
     Generated files will have a name constructed from the "doc_" prefix


### PR DESCRIPTION
Hi, this PR is based upon the previous one and optional. It makes the file encoding configurable, which is nice for Windows users not using Libreoffice.
The whole thing is basically a copy of the CSV separator functionality.
I've also taken the liberty of removing some trailing whitespace.