### PR TITLE
Fix a disabled option in logging

### DIFF
--- a/logging.conf
+++ b/logging.conf
@@ -19,8 +19,8 @@ formatter=simple
 
 [handler_file]
 class=handlers.RotatingFileHandler
-#args=(os.path.expanduser('~/.scribusGenerator.log'),'a','maxBytes=50','backupCount=1')  KO in Python 3
 args=(os.path.expanduser('~/.scribusGenerator.log'),'a')
+kwargs={'maxBytes': 50, 'backupCount': 1}
 formatter=full
 
 [formatter_simple]


### PR DESCRIPTION
A better fix than this [old fix for Python 3 logging](https://github.com/berteh/ScribusGenerator/commit/f7ccc2311d22cb99c31a4c8#diff-2ac1cb1c7308694346fb3448af88a060b2ca5eabfb4dfe02195be06700694d32).