### PR TITLE
Fix unescaped format characters in CLI script

### DIFF
--- a/ScribusGeneratorCLI.py
+++ b/ScribusGeneratorCLI.py
@@ -80,7 +80,7 @@ parser.add_argument('-e', '--csvEncoding', default=CONST.CSV_ENCODING,
 # parser.add_argument('-f', '--fast', '--noPdf', action='store_true', default=False, # commented utile Scribus allows pdf generation from command line
 #    help='no PDF generation, scribus SLA only (much faster)')
 parser.add_argument('-n', '--outName', default=CONST.EMPTY,
-                    help='name of the generated files, with no extension. Default is a simple incremental index. Using SG variables is allowed to define the name of generated documents. Use %VAR_COUNT% as a unique counter defined automatically from the data entry position.')
+                    help='name of the generated files, with no extension. Default is a simple incremental index. Using SG variables is allowed to define the name of generated documents. Use %%VAR_COUNT%% as a unique counter defined automatically from the data entry position.')
 parser.add_argument('-o', '--outDir', default=None,
                     help='directory were generated files are stored. Default is the directory of the scribus source file. outputDir will be created if it does not exist.')
 # parser.add_argument('-p', '--pdfOnly', '--noSla', action='store_true', default=False, # for pdf from CLI


### PR DESCRIPTION
Currently, running `./ScribusGeneratorCLI.py --help` (Python 3.10.12 on Ubuntu 22.04)

fails with

```ValueError: unsupported format character 'V' (0x56) at index 165```

due to an unescaped `%VAR_COUNT%` in the help text of the `--outName` argument. This PR escapes the format characters (`%%`) to get `--help` up again.