### PR TITLE
Fix merging of multi-page template documents

### DIFF
--- a/ScribusGeneratorBackend.py
+++ b/ScribusGeneratorBackend.py
@@ -628,8 +628,11 @@ class ScribusGenerator:
         groups_count,
         objects_count, version
     ):
-        vertical_offset = (float(page_height)+float(vertical_gap)) * \
-            (index // records_in_document)
+        vertical_offset = (
+            (float(page_height) + float(vertical_gap))
+            * (index // records_in_document)
+            * (pages_count // 2 if document_element.get("BOOK") == "1" else pages_count)
+        )
 
         #logging.debug("shifting to vertical_offset %s " % (vertical_offset))
 


### PR DESCRIPTION
Closes #218

Previously, when one record was taking more than one single page or more than two facing pages, the pages in the merged document would not be shifted properly and overlay each other (as described in #218).

To fix this, `vertical_offset` in the `shift_pages_and_objects` method needs to be multiplied by the number of single pages/facing page pairs in the template (which might be one for most use cases). This PR uses the number of template pages `pages_count` as that factor, conditionally divided by two in the case of a facing-page layout (i.e., when the `DOCUMENT` element has the `BOOK="1"` attribute).

I think the only case that is still not handled correctly with this PR is a facing-page template with an odd number of pages. In that case, some pages would also need to be shifted horizontally. Luckily, I cannot think of any practical use case for such a template :sweat_smile: