### PR TITLE
Fix capitalised datafile extension

### DIFF
--- a/ScribusGeneratorBackend.py
+++ b/ScribusGeneratorBackend.py
@@ -210,7 +210,7 @@ class ScribusGenerator:
         data = []
 
         # .. depending on file type
-        extension = os.path.splitext(data_file)[1]
+        extension = os.path.splitext(data_file)[1].lower()
 
         if extension == '.json':
             # .. from JSON file


### PR DESCRIPTION
Potential fix for issue #239 

Previously, using a capitalised datafile extension would cause it to not match the expected (lower case) extensions in the code, and not process the file at all. 